### PR TITLE
Harden dark-theme CSS and add Streamlit dark config to remove white widget boxes

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,7 @@
+[theme]
+base="dark"
+backgroundColor="#071423"
+secondaryBackgroundColor="#0b1b2b"
+textColor="#ffffff"
+primaryColor="#ff4b4b"
+font="sans serif"

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -32,6 +32,36 @@ html, body, [class*="css"] {
   color: var(--text);
 }
 
+
+.stApp [data-testid="stVerticalBlock"],
+.stApp [data-testid="stHorizontalBlock"],
+.stApp [data-testid="stColumn"],
+.stApp [data-testid="stMarkdownContainer"],
+.stApp [data-testid="stMetric"],
+.stApp [data-testid="stExpander"],
+.stApp [data-testid="stContainer"],
+.stApp [data-testid="stForm"],
+.stApp [data-testid="stToolbar"] {
+  background: transparent !important;
+}
+
+.stApp [data-baseweb="card"],
+.stApp [data-baseweb="popover"],
+.stApp [data-baseweb="menu"],
+.stApp [data-baseweb="select"],
+.stApp [data-baseweb="button"] {
+  background-color: transparent !important;
+}
+
+.stApp .element-container,
+.stApp .stMarkdown,
+.stApp .stMarkdown > div {
+  background: transparent !important;
+}
+
+.stApp [data-testid="stContainer"] {
+  background: rgba(11, 27, 43, 0) !important;
+}
 .block-container {
   padding-top: 0.55rem;
   padding-bottom: 1rem;


### PR DESCRIPTION
### Motivation
- Streamlit/BaseWeb wrapper layers were sometimes painting white backgrounds over the app’s dark theme in Cloud, producing visible white “widget boxes” that conflicted with the intended dark UI.

### Description
- Added hardened global widget background overrides to `src/styles/app.css` to force transparency for common Streamlit containers and BaseWeb surfaces (e.g. `stVerticalBlock`, `stHorizontalBlock`, `stColumn`, `stMarkdownContainer`, `stMetric`, `stExpander`, `stContainer`, `stForm`, `stToolbar`, and BaseWeb `card|popover|menu|select|button`).
- Added explicit markdown/container transparency rules (`.element-container`, `.stMarkdown`, `.stMarkdown > div`) and an `stContainer` background reset to cover Streamlit wrapper variations.
- Added `.streamlit/config.toml` with a dark theme (`base="dark"`) and matching token colors so Streamlit defaults align with the custom CSS in Cloud deployments.
- Confirmed `src.ui_components.app_styles()` already returns the stylesheet as `<style>...</style>` and `app.py` injects `styles = app_styles()` once at startup, so no changes were required to those files.

### Testing
- Ran `python -m py_compile app.py src/ui_components.py` which succeeded to validate Python sources.
- Ran `python -m pytest -q` which reported no tests were collected in this repository.
- Launched the app with `streamlit run app.py` and captured a screenshot to visually verify that lingering white widget backgrounds were removed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a416ad4a008331bbf5ca79a00b34b2)