### PR TITLE
Refactor app toward UI-agnostic core with ports/adapters and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ An AI-styled Streamlit app that creates EuroMillions lines from historical draws
 
 ## Architecture
 
-- `core/` → pure logic (portable to backend/iOS)
-- `services/` → external data providers
-- `ui_streamlit/` → Streamlit UI only
-- `api_fastapi/` → backend API layer
+- `src/core/` → pure business logic and domain models (`Draw`, `Line`, `Ticket`), plus date/draw/ticket logic. No Streamlit imports.
+- `src/services/` → adapters that implement provider ports for draws, jackpot lookup, and ticket persistence.
+- `src/ui_streamlit/` + `app.py` → current Streamlit presentation layer.
+- `src/api_fastapi/` → optional backend surface that can reuse `src/core/` directly.
+
+This split keeps the prediction and ticket engine UI-agnostic, so a future FastAPI backend or iOS client can call the same core modules without rewriting business rules.
 
 ## Running locally
 

--- a/src/core/draws.py
+++ b/src/core/draws.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from src.core.models import Draw
+
+
+DRAW_DATE_KEYS = ("date", "drawDate", "draw_date")
+JACKPOT_KEYS = ("estimatedJackpot", "jackpot", "jackpotAmount", "topPrize", "jackpot_amount")
+
+
+def parse_date_like(value: object) -> date | None:
+    if value in (None, ""):
+        return None
+
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).date()
+    except ValueError:
+        pass
+
+    for pattern in ("%Y-%m-%d", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(text, pattern).date()
+        except ValueError:
+            continue
+
+    return None
+
+
+def draw_date_text(draw: dict) -> str:
+    for key in DRAW_DATE_KEYS:
+        value = draw.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return ""
+
+
+def parse_draw_timestamp(draw: dict) -> float:
+    for key in DRAW_DATE_KEYS:
+        value = draw.get(key)
+        parsed = parse_date_like(value)
+        if parsed is None:
+            continue
+        return datetime(parsed.year, parsed.month, parsed.day, tzinfo=timezone.utc).timestamp()
+    return float("-inf")
+
+
+def normalize_int_list(values: list | None) -> list[int]:
+    normalized: list[int] = []
+    for value in values or []:
+        try:
+            normalized.append(int(value))
+        except (TypeError, ValueError):
+            continue
+    return normalized
+
+
+def normalize_draw_dict(draw: dict) -> dict:
+    normalized = dict(draw)
+    normalized["numbers"] = normalize_int_list(draw.get("numbers"))
+    normalized["stars"] = normalize_int_list(draw.get("stars"))
+    return normalized
+
+
+def prepare_draws(draws: list[dict] | None, history_n: int) -> list[dict]:
+    normalized = [normalize_draw_dict(draw) for draw in (draws or [])]
+    ordered = sorted(normalized, key=parse_draw_timestamp, reverse=True)
+    return ordered[:history_n]
+
+
+def parse_optional_jackpot(draw: dict) -> int | None:
+    for key in JACKPOT_KEYS:
+        raw = draw.get(key)
+        if raw in (None, ""):
+            continue
+        cleaned = "".join(ch for ch in str(raw) if ch.isdigit())
+        if cleaned:
+            return int(cleaned)
+    return None
+
+
+def draw_from_payload(payload: dict, *, source: str | None = None) -> Draw | None:
+    draw_date = parse_date_like(draw_date_text(payload))
+    if draw_date is None:
+        return None
+
+    return Draw(
+        draw_date=draw_date,
+        numbers=sorted(normalize_int_list(payload.get("numbers"))),
+        stars=sorted(normalize_int_list(payload.get("stars"))),
+        jackpot=parse_optional_jackpot(payload),
+        source=source,
+        source_draw_id=str(payload.get("drawNo") or payload.get("drawNumber") or "") or None,
+    )
+
+
+def draw_to_payload(draw: Draw) -> dict:
+    return {
+        "date": draw.draw_date.isoformat(),
+        "numbers": list(draw.numbers),
+        "stars": list(draw.stars),
+        "jackpot": draw.jackpot,
+        "source": draw.source,
+        "drawNo": draw.source_draw_id,
+    }

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+
+
+@dataclass(frozen=True)
+class Draw:
+    draw_date: date
+    numbers: list[int]
+    stars: list[int]
+    jackpot: int | None = None
+    source: str | None = None
+    source_draw_id: str | None = None
+
+
+@dataclass(frozen=True)
+class Line:
+    main: list[int]
+    stars: list[int]
+
+
+@dataclass(frozen=True)
+class Ticket:
+    id: str
+    created_at: str
+    draw_date: str
+    draw_label: str
+    strategy: str
+    lines: list[Line] = field(default_factory=list)
+    status: str = "Pending"
+    notes: str = ""

--- a/src/core/ports.py
+++ b/src/core/ports.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from src.core.models import Draw, Ticket
+
+
+@dataclass(frozen=True)
+class JackpotMeta:
+    ok: bool
+    source: str
+    jackpot_amount: str | None
+    next_draw_date: str | None
+    next_draw_day: str | None
+    raw: str | None
+    error: str | None
+
+
+class DrawsProvider(Protocol):
+    def fetch_draws(self) -> list[Draw]:
+        ...
+
+
+class JackpotProvider(Protocol):
+    def get_jackpot(self) -> JackpotMeta:
+        ...
+
+
+class TicketStore(Protocol):
+    def load(self) -> list[Ticket]:
+        ...
+
+    def save(self, tickets: list[Ticket]) -> None:
+        ...

--- a/src/core/tickets.py
+++ b/src/core/tickets.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+import uuid
+
+from src.core.models import Line, Ticket
+from src.core.draws import parse_date_like
+
+
+def as_iso_date(value: object) -> str | None:
+    parsed = parse_date_like(value)
+    return parsed.isoformat() if parsed else None
+
+
+def safe_ticket_lines(lines: list[dict] | None) -> list[Line]:
+    validated: list[Line] = []
+    for line in lines or []:
+        if not isinstance(line, dict):
+            continue
+
+        main_numbers = line.get("main", [])
+        stars = line.get("stars", [])
+        if not isinstance(main_numbers, list) or not isinstance(stars, list):
+            continue
+
+        try:
+            main = sorted(int(v) for v in main_numbers)
+            star_vals = sorted(int(v) for v in stars)
+        except (TypeError, ValueError):
+            continue
+
+        validated.append(Line(main=main, stars=star_vals))
+
+    return validated
+
+
+def new_ticket(lines: list[dict], strategy: str, draw_date_iso: str, draw_label: str) -> Ticket:
+    return Ticket(
+        id=str(uuid.uuid4()),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        draw_date=draw_date_iso,
+        draw_label=draw_label,
+        strategy=strategy,
+        lines=safe_ticket_lines(lines),
+        status="Pending",
+        notes="",
+    )
+
+
+def count_line_matches(line: Line, winning_mains: set[int], winning_stars: set[int]) -> int:
+    return sum(1 for value in line.main if value in winning_mains) + sum(1 for value in line.stars if value in winning_stars)
+
+
+def prepare_ticket_match_rows(
+    ticket: Ticket,
+    *,
+    winning_mains: set[int],
+    winning_stars: set[int],
+    should_check_matches: bool,
+    pending_label: str | None = None,
+) -> list[dict]:
+    rows: list[dict] = []
+    for line in ticket.lines[:5]:
+        matched_mains = set(line.main) & winning_mains if should_check_matches else set()
+        matched_stars = set(line.stars) & winning_stars if should_check_matches else set()
+        rows.append(
+            {
+                "main": list(line.main),
+                "stars": list(line.stars),
+                "matched_mains": matched_mains,
+                "matched_stars": matched_stars,
+                "matches": count_line_matches(line, winning_mains, winning_stars) if should_check_matches else "—",
+                "pending_label": pending_label,
+            }
+        )
+    return rows
+
+
+def ticket_to_dict(ticket: Ticket) -> dict:
+    payload = asdict(ticket)
+    payload["lines"] = [asdict(line) for line in ticket.lines]
+    return payload
+
+
+def ticket_from_dict(payload: dict) -> Ticket | None:
+    if not isinstance(payload, dict):
+        return None
+
+    lines = safe_ticket_lines(payload.get("lines", []))
+    return Ticket(
+        id=str(payload.get("id") or str(uuid.uuid4())),
+        created_at=str(payload.get("created_at") or datetime.now(timezone.utc).isoformat()),
+        draw_date=str(payload.get("draw_date") or ""),
+        draw_label=str(payload.get("draw_label") or ""),
+        strategy=str(payload.get("strategy") or "Unknown strategy"),
+        lines=lines,
+        status=str(payload.get("status") or "Pending"),
+        notes=str(payload.get("notes") or ""),
+    )

--- a/src/services/draws_provider_http.py
+++ b/src/services/draws_provider_http.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import requests
+
+from src.core.draws import draw_from_payload
+from src.core.models import Draw
+
+DRAWS_API_URL = "https://euromillions.api.pedromealha.dev/v1/draws"
+
+
+class HttpDrawsProvider:
+    def __init__(self, api_url: str = DRAWS_API_URL, timeout: int = 10) -> None:
+        self.api_url = api_url
+        self.timeout = timeout
+
+    def fetch_draws(self) -> list[Draw]:
+        response = requests.get(self.api_url, timeout=self.timeout)
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, list):
+            return []
+
+        draws: list[Draw] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            draw = draw_from_payload(item, source="pedromealha")
+            if draw is not None:
+                draws.append(draw)
+        return draws

--- a/src/services/jackpot_provider.py
+++ b/src/services/jackpot_provider.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from src.core.ports import JackpotMeta
+from src.jackpot_service import get_live_jackpot
+
+
+class LiveJackpotProvider:
+    def get_jackpot(self) -> JackpotMeta:
+        info = get_live_jackpot()
+        return JackpotMeta(
+            ok=info.ok,
+            source=info.source,
+            jackpot_amount=info.jackpot_amount,
+            next_draw_date=info.next_draw_date,
+            next_draw_day=info.next_draw_day,
+            raw=info.raw,
+            error=info.error,
+        )

--- a/src/services/ticket_store_localstorage.py
+++ b/src/services/ticket_store_localstorage.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from src.core.models import Ticket
+from src.core.tickets import ticket_from_dict, ticket_to_dict
+from src.services.ticket_store import load_tickets_from_localstorage, save_tickets_to_localstorage
+
+
+class LocalStorageTicketStore:
+    def load(self) -> list[Ticket]:
+        payload = load_tickets_from_localstorage()
+        tickets: list[Ticket] = []
+        for item in payload:
+            ticket = ticket_from_dict(item)
+            if ticket is not None:
+                tickets.append(ticket)
+        return tickets
+
+    def save(self, tickets: list[Ticket]) -> None:
+        save_tickets_to_localstorage([ticket_to_dict(ticket) for ticket in tickets])

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from src.date_utils import format_uk_date
 from html import escape
 
-import streamlit as st
-
 
 def _first_available(draw: dict, keys: tuple[str, ...]) -> object | None:
     for key in keys:
@@ -142,11 +140,8 @@ def render_app_header(app_name: str = "Wilkos LuckyLogic", tagline: str = "Smart
     """
 
 
-def render_balls(main_nums: list[int], stars: list[int]) -> None:
-    st.markdown(
-        render_number_balls(main_nums, stars),
-        unsafe_allow_html=True,
-    )
+def render_balls(main_nums: list[int], stars: list[int]) -> str:
+    return render_number_balls(main_nums, stars)
 
 
 def render_number_balls(
@@ -182,15 +177,14 @@ def render_number_balls(
     )
 
 
-def render_insight_card(title: str, body: str, icon: str = "") -> None:
-    st.markdown(
+def render_insight_card(title: str, body: str, icon: str = "") -> str:
+    return (
         f"""
         <div class="insight-card">
             <div class="insight-title"><span class="insight-icon">{icon}</span>{title}</div>
             <div class="insight-body">{body}</div>
         </div>
-        """,
-        unsafe_allow_html=True,
+        """
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_core_architecture.py
+++ b/tests/test_core_architecture.py
@@ -1,0 +1,38 @@
+from datetime import date
+
+from src.core.draw_dates import upcoming_draw_dates
+from src.core.draws import prepare_draws
+from src.core.models import Line
+from src.core.tickets import count_line_matches
+
+
+def test_draw_date_parsing_and_sorting() -> None:
+    draws = [
+        {"date": "2026-03-03", "numbers": [1, "2", 3], "stars": [1, "2"]},
+        {"drawDate": "01/03/2026", "numbers": [5, 6, 7], "stars": [3, 4]},
+        {"draw_date": "2026-03-07T00:00:00Z", "numbers": [8, 9, 10], "stars": [5, 6]},
+    ]
+
+    prepared = prepare_draws(draws, history_n=3)
+
+    assert [item.get("numbers") for item in prepared] == [
+        [8, 9, 10],
+        [1, 2, 3],
+        [5, 6, 7],
+    ]
+
+
+def test_ticket_match_count() -> None:
+    line = Line(main=[3, 11, 19, 27, 45], stars=[2, 9])
+
+    matches = count_line_matches(line, winning_mains={11, 27, 42}, winning_stars={9, 12})
+
+    assert matches == 3
+
+
+def test_upcoming_draw_dates() -> None:
+    draws = upcoming_draw_dates(date(2026, 3, 2), weeks=2)
+
+    assert len(draws) == 4
+    assert all(draw.weekday() in {1, 4} for draw in draws)
+    assert draws[0] == date(2026, 3, 3)


### PR DESCRIPTION
### Motivation
- Decouple business logic from the Streamlit UI so the prediction and ticket engine can be reused by a future FastAPI backend or an iOS client.  
- Replace ad-hoc, UI-coupled persistence and parsing with explicit provider interfaces to allow swappable adapters for draws, jackpot and ticket storage.  
- Add small headless tests to protect key rules (date parsing/order, match counting, Tue/Fri draw schedule) without requiring Streamlit in CI.

### Description
- Introduced domain models in `src/core/models.py` (`Draw`, `Line`, `Ticket`) and provider interfaces in `src/core/ports.py` (`DrawsProvider`, `JackpotProvider`, `TicketStore`, plus `JackpotMeta`).
- Moved draw parsing/normalization/sorting and payload/domain conversions into `src/core/draws.py`, and moved ticket creation/validation/match-prep into `src/core/tickets.py`, making core logic Streamlit-free and well-typed.  
- Implemented adapters in `src/services/`: `src/services/draws_provider_http.py` (HTTP draws provider), `src/services/jackpot_provider.py` (wrapper around existing `src/jackpot_service`), and `src/services/ticket_store_localstorage.py` (localStorage-backed ticket store).  
- Refactored `app.py` to depend on the provider ports and core helpers (composition root constructs `HttpDrawsProvider`, `LiveJackpotProvider`, `LocalStorageTicketStore`), and cleaned `src/ui_components.py` so helpers return markup (no side-effect Streamlit rendering inside reusable helpers); README architecture section updated to document the split.

### Testing
- Static/compile check: ran `python -m py_compile` across modified modules and it completed successfully.  
- Unit tests: ran `pytest -q` and all tests passed (`3 passed`).  
- Smoke UI run: started a headless Streamlit run (`streamlit run app.py --server.headless true --server.port 8501`) in a short-timeout smoke-run and observed normal startup output (app served locally), indicating no immediate regressions in the Streamlit entrypoint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a42ddf7ebc8331ac3de185c17eed84)